### PR TITLE
Connect Persistence to UUID and Document in Stunned

### DIFF
--- a/animations/pf2e/conditions/stunned.json
+++ b/animations/pf2e/conditions/stunned.json
@@ -72,8 +72,8 @@
     {
       "type": "persist",
       "position": {
-        "x": 2608.8888888888887,
-        "y": 47.88888888888903
+        "x": 2605.1746031746034,
+        "y": 129.03174603174625
       },
       "id": "icMdaJ1q3j1VHfPK",
       "inputs": {
@@ -88,6 +88,12 @@
         },
         "effect": {
           "connection": "ABAJCIw3G7MVsfps:outputs:effect"
+        },
+        "tieTo": {
+          "connection": "Rk8e96ye0h2EOeUn:outputs:70aosF6hawepmW0s"
+        },
+        "tieToDocs": {
+          "connection": "ictQRW7Z9AdiNNAX:outputs:sources"
         }
       },
       "outs": {
@@ -468,5 +474,6 @@
   "name": "Stunned",
   "description": "<p>Written by @Chasarooni</p>",
   "folder": "Conditions",
-  "id": "w8aGmWUuPArAJELj"
+  "id": "IBv2MCNFgFqcGBSU",
+  "tags": ["PF2e Trove", "pf2e", "conditions"]
 }


### PR DESCRIPTION
The Persistence node in the Stunned trigger was missing its links to Tie To UUIDs and Tie To Documents, which prevented it from being removed from the token when the condition was removed.
<img width="305" height="460" alt="Capture d&#39;écran 2026-07-17 210517" src="https://github.com/user-attachments/assets/11aac65c-a37d-4e87-b52f-790b28cf8cc8" />
