### PR TITLE
Fix Solar Weapon

### DIFF
--- a/animations/sf2e/attacks/weapons/specific/solar-weapon.json
+++ b/animations/sf2e/attacks/weapons/specific/solar-weapon.json
@@ -261,7 +261,7 @@
       },
       "outs": {
         "out": {
-          "connection": "cpgrcUOgsEUnsTlf:ins:in"
+          "connection": "v2ziZu56zWhfRrBI:ins:in"
         }
       }
     },
@@ -1185,9 +1185,30 @@
           "connection": "ciMzjnDUhWrio2aM:ins:in"
         }
       }
+    },
+    {
+      "type": "split-boolean",
+      "position": {
+        "x": 2251.173076923077,
+        "y": -323.75
+      },
+      "id": "v2ziZu56zWhfRrBI",
+      "inputs": {
+        "input": {
+          "connection": "49KMjmeoYAMf0FX7:outputs:JtmUyVpJEcCw8Qd7"
+        }
+      },
+      "outs": {
+        "false": {
+          "connection": "tSmUCKf6uG0ZfHyZ:ins:in"
+        },
+        "true": {
+          "connection": "T6tBt1r5Rma0TU3n:ins:in"
+        }
+      }
     }
   ],
-  "id": "mNQgan9bXe7MfUWW",
+  "id": "9HpLaImUmVO5oI0j",
   "variables": {
     "59DxE5yps3tZvxN0:outputs:target": {
       "isArray": false,


### PR DESCRIPTION
This should fix the issue where Solar Weapon animations don't work anymore.
It looks like one of the nodes was lost during the merge conflict a few weeks ago.
I hope there won't be conflicts this time^^;